### PR TITLE
Feature/mwe 181 individual applications should be moved to web engine packages

### DIFF
--- a/apps-ui/dashing-bumblebee-ui/app/page.tsx
+++ b/apps-ui/dashing-bumblebee-ui/app/page.tsx
@@ -24,9 +24,9 @@ export default function Page() {
 
     /* .assetUrls['backgroundImage'] ??    .assetUrls['backgroundImage'] ?? '' */
     return (
-        <section className="hero bg-background bg-gradient-to-r from-green-100 backdrop-blur-sm ">
+        <section className="hero bg-gray-800">
             { /* JSON.stringify(contentRoot) */} 
-            <div className="hero-content container flex  flex-col">
+            <div className="hero-content flex-col">
                 <HeroTheOneContainer cards={heroTheOneData} />
                 <HeroTheTwoContainer cards={heroTheTwoData} />
                 <CardContainer cards={cardData} />

--- a/apps-ui/dashing-bumblebee-ui/tailwind.config.ts
+++ b/apps-ui/dashing-bumblebee-ui/tailwind.config.ts
@@ -5,12 +5,14 @@ module.exports = {
     content: ['./app/**/*.{js,ts,jsx,tsx,mdx}', '../../packages-ui/mwe-ui-core/src/**/*.{js,ts,jsx,tsx,mdx}'],
     theme: {
         screens: {
-            xs: '480px', // Extra Small
-            sm: '640px', // Small
-            md: '768px', // Medium
+            xs: '480px',  // Extra Small
+            sm: '640px',  // Small
+            md: '768px',  // Medium
             lg: '1024px', // Large
             xl: '1280px', // Extra Large
-        },
+            xxl: '1920px', // Extra Extra Large
+
+          },
         extend: {
             zIndex: {
                 '0': '0',
@@ -20,9 +22,7 @@ module.exports = {
                 '4': '4',
                 '5': '5',
             },
-            fontFamily: {
-                'press-start': ['"Oswald"'],
-            },
+            
             backgroundImage: {
                 'gradient-to-r': 'linear-gradient(to right, #628A1D, #2085A1)', // Példa gradient
             },

--- a/packages-ui/ui-core/src/ui-card/components/Card.tsx
+++ b/packages-ui/ui-core/src/ui-card/components/Card.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { CardData } from '../types';
 import '../style/style.css';
 
+
 const Card: React.FC<CardData> = (props) => {
     const { title, imageUrl, imageAlt, description } = props;
     return (
-        <div className="container flex flex-col items-center p-4 bg-secondary">
+        <div className="flex flex-col items-center sm:gap-6 rounded-box m-4 p-4 text-white bg-secondary hover:bg-base-content">
             <div className="text-center max-w-xs p-3">
                 <div className="w-32 h-30 sm:w-28 sm:h-28 lg:w-40 lg:h-40 mx-auto">
                     <div className="z-10 relative w-full h-full flex items-center justify-center">

--- a/packages-ui/ui-core/src/ui-card/components/CardContainer.tsx
+++ b/packages-ui/ui-core/src/ui-card/components/CardContainer.tsx
@@ -12,17 +12,10 @@ const CardContainer: React.FC<CardContainerProps> = (props) => {
     const [contentRoot] = useAtom(contentRootAtomRW);
     const contentRootLeafs = contentRoot['home']?.leafs ?? {};
     const cardData: CardData[] = contentRootLeafs['coverCards']?.textContentCollection ?? [];
-    const { cards } = props;
-
+    
     return (
         <div
-            className={`
-        bg-primary
-        center
-        align-items-center
-        sm:grid-cols-3
-        flex 
-        `}
+            className={"bg-primary center align-items-center sm:grid-cols-12 flex"}
         >
             {cardData.map((card, i) => (
                 <Card

--- a/packages-ui/ui-core/src/ui-card/components/CardTheTwo.tsx
+++ b/packages-ui/ui-core/src/ui-card/components/CardTheTwo.tsx
@@ -5,8 +5,7 @@ import '../style/style.css';
 const CardTheTwo: React.FC<CardData> = (props) => {
     const { title, imageUrl, description } = props;
     return (
-        <div className={`
-        flex flex-col items-center gap-4 sm:gap-6 my-3 rounded-box font-press-start bg-secondary p-3 hover:bg-base-content`}
+        <div className={"flex flex-col items-center gap-4 sm:gap-6 my-3 rounded-box font-press-start bg-secondary p-3 hover:bg-base-content"}
         >
             <figure className="rounded-full relative w-28 h-20 sm:w-28 sm:h-28 lg:w-32 lg:h-32 mx-auto">
                 <img src={imageUrl} className="rounded-full w-32 h-32 object-cover" />

--- a/packages-ui/ui-core/src/ui-card/components/CardTheTwoContainer.tsx
+++ b/packages-ui/ui-core/src/ui-card/components/CardTheTwoContainer.tsx
@@ -12,17 +12,11 @@ const CardTheTwoContainer: React.FC<CardTheTwoContainerProps> = (props) => {
     const [contentRoot] = useAtom(contentRootAtomRW);
     const contentRootLeafs = contentRoot['home']?.leafs ?? {};
     const cardTheTwoData: CardData[] = contentRootLeafs['coverCardsSecondary']?.textContentCollection ?? [];
-    const { cards } = props;
+    
 
     return (
         <div
-            className="bg-primary
-         
-        sm:grid-cols-3 
-        gap-4 
-        sm:gap-6 
-        flex
-        rounded-box "
+            className="bg-primary sm:grid-cols-3 gap-4 sm:gap-6 flex rounded-box "
         >
             {cardTheTwoData.map((card, i) => (
                 <CardTheTwo key={i} title={card.title} description={card.description} imageUrl={card.imageUrl} />

--- a/packages-ui/ui-core/src/ui-card/components/HeroTheOne.tsx
+++ b/packages-ui/ui-core/src/ui-card/components/HeroTheOne.tsx
@@ -6,7 +6,7 @@ const HeroTheOne: React.FC<CardData> = (props) => {
     const { title, description, imageUrl, imageAlt } = props;
 
     return (
-        <div className="container flex flex-col md:flex-row items-start ">
+        <div className="container mx-auto flex flex-col md:flex-row justify-between items-start">
             
                 <img src={imageUrl} alt={imageAlt} className="w-full" />
                 <h2 className="text-5xl font-bold  mb-2  p-5">{title}</h2>

--- a/packages-ui/ui-core/src/ui-card/components/HeroTheOneContainer.tsx
+++ b/packages-ui/ui-core/src/ui-card/components/HeroTheOneContainer.tsx
@@ -12,7 +12,7 @@ const HeroTheOneContainer: React.FC<HeroTheOneContainerProps> = (props) => {
     const [contentRoot] = useAtom(contentRootAtomRW);
     const contentRootLeafs = contentRoot['home']?.leafs ?? {};
     const heroTheOneData: CardData[] = contentRootLeafs['heroTheOne']?.textContentCollection ?? [];
-    const { cards } = props;
+    
 
     return (
         <div>

--- a/packages-ui/ui-core/src/ui-card/components/HeroTheTwoContainer.tsx
+++ b/packages-ui/ui-core/src/ui-card/components/HeroTheTwoContainer.tsx
@@ -12,7 +12,7 @@ const HeroTheTwoContainer: React.FC<HeroTheTwoContainerProps> = (props) => {
     const [contentRoot] = useAtom(contentRootAtomRW);
     const contentRootLeafs = contentRoot['home']?.leafs ?? {};
     const heroTheTwoData: CardData[] = contentRootLeafs['heroTheTwo']?.textContentCollection ?? [];
-    const { cards } = props;
+    
 
     return (
         <div>

--- a/packages-ui/ui-core/src/ui-card/components/ImageCardContainer.tsx
+++ b/packages-ui/ui-core/src/ui-card/components/ImageCardContainer.tsx
@@ -15,14 +15,7 @@ const ImageCardContainer: React.FC<ImageCardContainerProps> = (props) => {
 
     return (
         <div
-            className={`
-        bg-primary
-        flex
-        mb-4
-        pl-10
-        sm:grid-cols-7
-        rounded-box 
-        `}
+            className={"bg-primary flex mb-4 pl-10 sm:grid-cols-7 rounded-box "}
         >
             {imageCardData.map((card, i) => (
                 <ImageCard key={i} imageUrl={card.imageUrl} imageAlt={card.imageAlt} />

--- a/packages-ui/ui-core/src/ui-nav-menu/components/NavBar.tsx
+++ b/packages-ui/ui-core/src/ui-nav-menu/components/NavBar.tsx
@@ -14,7 +14,7 @@ export type NavBarProps = {
 
 const NavBar: React.FC<NavBarProps> = (props) => {
     return (
-        <div className="navbar bg-neutral fixed top-0 w-full z-5 ">
+        <div className="navbar fixed top-0 w-full z-5 ">
             <NavMenu />
         </div>
     );

--- a/packages-ui/ui-core/src/ui-nav-menu/components/NavMenu.tsx
+++ b/packages-ui/ui-core/src/ui-nav-menu/components/NavMenu.tsx
@@ -15,7 +15,7 @@ const NavMenu: React.FC = () => {
 
     return (
         <nav className="navbar">
-            {JSON.stringify(navRoot)}
+             { /*JSON.stringify(navRoot) */}
 
             <div className="nav-menu flex">
                 {Object.keys(navRoot).map((navBranch) => (

--- a/packages-ui/ui-core/src/ui-nav-menu/styles/navbar.css
+++ b/packages-ui/ui-core/src/ui-nav-menu/styles/navbar.css
@@ -1,5 +1,7 @@
 .navbar {
     @apply flex justify-center w-full text-[white];
+    background: linear-gradient(45deg, #306825, #3f3f41);
+    background: rgb(75, 72, 72);
 }
 
 .nav-menu {


### PR DESCRIPTION
ui-card/ components - Containers need props?  

const ImageCardContainer: React.FC<ImageCardContainerProps> = (props) => { 
    const [contentRoot] = useAtom(contentRootAtomRW);
    const contentRootLeafs = contentRoot['home']?.leafs ?? {};
    const imageCardData: ImageCardData[] = contentRootLeafs['imageCards']?.textContentCollection ?? [];
    const { cards } = props; 

const ImageCard: React.FC<ImageCardData> = (props) => {
    const { imageUrl, imageAlt } = props;